### PR TITLE
Fix Update Groupname 100

### DIFF
--- a/app/src/EditGroups.tsx
+++ b/app/src/EditGroups.tsx
@@ -171,6 +171,7 @@ function handleUpdateGroupName(
       }
     });
     groups.delete(input.oldGroupName);
+    group.name = input.newGroupName;
     return new Map([...groups.set(input.newGroupName, group).entries()].sort());
   } else {
     return groups;


### PR DESCRIPTION
1) need to set group name to input.newGroupName before returning the map. This will allow rulelist to list down the correct list of groups