### PR TITLE
Fix extractpage and GEMMain

### DIFF
--- a/app/src/extractConfigReducer.tsx
+++ b/app/src/extractConfigReducer.tsx
@@ -48,10 +48,10 @@ export const extractConfigInitialState: ExtractConfig = {
 };
 
 // hardcoded list the extractors
-export const CSV_EXTRACTOR = "innohack.gem.service.extract.CSVExtractor";
-export const EXCEL_EXTRACTOR = "innohack.gem.service.extract.ExcelExtractor";
+export const CSV_EXTRACTOR = "innohack.gem.core.extract.CSVExtractor";
+export const EXCEL_EXTRACTOR = "innohack.gem.core.extract.ExcelExtractor";
 export const TIKA_CONTENT_EXTRACTOR =
-  "innohack.gem.service.extract.TikaContentExtractor";
+  "innohack.gem.core.extract.TikaContentExtractor";
 
 export default function extractConfigReducer(
   state: ExtractConfig,

--- a/src/main/java/innohack/gem/core/entity/extract/ExtractedRecords.java
+++ b/src/main/java/innohack/gem/core/entity/extract/ExtractedRecords.java
@@ -1,6 +1,7 @@
 package innohack.gem.core.entity.extract;
 
 import com.beust.jcommander.internal.Lists;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ExtractedRecords {
@@ -9,11 +10,21 @@ public class ExtractedRecords {
 
   private List<List<String>> records;
 
-  private List<String> groups;
+  private String group;
 
   public ExtractedRecords() {
     headers = Lists.newArrayList();
     records = Lists.newArrayList();
+  }
+
+  public ExtractedRecords(String group, List<String> headers, List<List<String>> records) {
+    this.group = group;
+    this.headers = headers;
+    this.records = records;
+  }
+
+  public static ExtractedRecords empty(String group) {
+    return new ExtractedRecords(group, new ArrayList<>(), new ArrayList<>());
   }
 
   public List<String> getHeaders() {
@@ -36,11 +47,11 @@ public class ExtractedRecords {
     return records.size();
   }
 
-  public List<String> getGroups() {
-    return groups;
+  public String getGroup() {
+    return group;
   }
 
-  public void setGroups(List<String> groups) {
-    this.groups = groups;
+  public void setGroup(String group) {
+    this.group = group;
   }
 }

--- a/src/test/java/innohack/gem/core/GEMMainTest.java
+++ b/src/test/java/innohack/gem/core/GEMMainTest.java
@@ -26,4 +26,34 @@ public class GEMMainTest {
     assertEquals(5, recordsList.get(0).getRecords().size());
     assertEquals("Sam", recordsList.get(0).getRecords().get(0).get(1));
   }
+
+  @Test
+  public void testNoExtractor() throws Exception {
+    String file = "src/test/resources/reviews.csv";
+    String spec = "src/test/resources/core/spec_no_extractor.json";
+    ObjectMapper mapper = new ObjectMapper();
+    Project project = mapper.readValue(new File(spec), Project.class);
+    File f = new File(file);
+
+    List<ExtractedRecords> recordsList = GEMMain.process(f, project);
+    assertEquals(1, recordsList.size());
+    assertEquals("csv-customer", recordsList.get(0).getGroup());
+    assertEquals(0, recordsList.get(0).getRecords().size());
+    assertEquals(0, recordsList.get(0).getHeaders().size());
+  }
+
+  @Test
+  public void testNoGroup() throws Exception {
+    String file = "src/test/resources/reviews.csv";
+    String spec = "src/test/resources/core/spec_no_group.json";
+    ObjectMapper mapper = new ObjectMapper();
+    Project project = mapper.readValue(new File(spec), Project.class);
+    File f = new File(file);
+
+    List<ExtractedRecords> recordsList = GEMMain.process(f, project);
+    assertEquals(1, recordsList.size());
+    assertEquals("NIL", recordsList.get(0).getGroup());
+    assertEquals(0, recordsList.get(0).getRecords().size());
+    assertEquals(0, recordsList.get(0).getHeaders().size());
+  }
 }

--- a/src/test/resources/core/spec_no_extractor.json
+++ b/src/test/resources/core/spec_no_extractor.json
@@ -1,0 +1,31 @@
+{
+  "specVersion" : "1.0.0",
+  "groups" : [ {
+    "groupId" : 8,
+    "name" : "csv-customer",
+    "rules" : [ {
+      "ruleId" : "innohack.gem.core.rules.FileExtension",
+      "label" : "File Extension",
+      "ruleType" : "FILE",
+      "name" : "FE-8",
+      "params" : [ {
+        "label" : "File extension",
+        "placeholder" : "txt",
+        "value" : "csv",
+        "type" : "STRING"
+      } ]
+    }, {
+      "ruleId" : "innohack.gem.core.rules.CsvHeaderColumnValue",
+      "label" : "CSV Header Column Value",
+      "ruleType" : "CSV",
+      "name" : "CHCV-2",
+      "params" : [ {
+        "label" : "Headers",
+        "placeholder" : "aa,bb,cc",
+        "value" : "Sender",
+        "type" : "STRING_LIST"
+      } ]
+    } ]
+  }],
+  "projectName" : "1.0"
+}

--- a/src/test/resources/core/spec_no_group.json
+++ b/src/test/resources/core/spec_no_group.json
@@ -1,0 +1,47 @@
+{
+  "specVersion" : "1.0.0",
+  "groups" : [ {
+    "groupId" : 7,
+    "name" : "csv-sender",
+    "rules" : [ {
+      "ruleId" : "innohack.gem.core.rules.FileExtension",
+      "label" : "File Extension",
+      "ruleType" : "FILE",
+      "name" : "FE-7",
+      "params" : [ {
+        "label" : "File extension",
+        "placeholder" : "txt",
+        "value" : "xxx",
+        "type" : "STRING"
+      } ]
+    }, {
+      "ruleId" : "innohack.gem.core.rules.CsvHeaderColumnValue",
+      "label" : "CSV Header Column Value",
+      "ruleType" : "CSV",
+      "name" : "CHCV-1",
+      "params" : [ {
+        "label" : "Headers",
+        "placeholder" : "aa,bb,cc",
+        "value" : "sender",
+        "type" : "STRING_LIST"
+      } ]
+    } ],
+    "extractConfig" : {
+      "tableName" : "Sender",
+      "columnNames" : [ "Id", "Sender_Name" ],
+      "timestampColumns" : [ ],
+      "groupId" : 7,
+      "extractor" : {
+        "extractorId" : "innohack.gem.core.extract.CSVExtractor",
+        "label" : "CSV Extractor",
+        "params" : [ {
+          "label" : "Column Names",
+          "placeholder" : "",
+          "value" : "Id,Sender",
+          "type" : "STRING_LIST"
+        } ]
+      }
+    }
+  } ],
+  "projectName" : "1.0"
+}


### PR DESCRIPTION
- fix extract page crashing problem
- GEMMain extract method handles file with no group, and group with no extractconfig
- change ExtractRecords group association to 1-to-1 relationship instead of 1-to-many because one Group can only produce one ExtractRecords per file.